### PR TITLE
Support HTML features in Katex and support filename params in the breadcrumb and the sidebar

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -5,7 +5,13 @@
 
         <div class="home">
             <div class="title">
-                <h1 class="title-caption">{{ $.Site.Params.header.title }}</h1>
+                {{ with $.Site.Params.header.logoImage }}
+                    <img class="logo" src="{{ $.Site.BaseURL }}{{ . }}"/>
+                {{ end }}
+
+                {{ with $.Site.Params.header.title }}
+                    <h1 class="title-caption">{{ . }}</h1>
+                {{ end }}
 
                 {{ with $.Site.Params.header.subtitle }}
                     <h2 class="subtitle">
@@ -53,12 +59,14 @@
                         {{ end }}
                     </div>
                 </div>
+                {{ if not $.Site.Params.homePage.disableWalkthroughs }}
                 <div class="right">
                     <h3 class="recommend-title">
                         {{ i18n "walkthroughs"  | title }}
                     </h3>
                     {{ partial "module/section_tree" ( dict "context" . "currentPage" . ) }}
                 </div>
+                {{ end }}
             </div>
         </div>
     </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,9 @@
     <article class="main">
         {{ partial "module/sidebar_btn" . }}
 
-
+        {{ with $.Site.Params.page.logoImage }}
+            <img class="logo" src="{{ $.Site.BaseURL }}{{ . }}"/>
+        {{ end }}
         <div class="title">
             <h1 class="title-header">
                 {{ .Title }}

--- a/layouts/partials/module/breadcrumb.html
+++ b/layouts/partials/module/breadcrumb.html
@@ -18,6 +18,8 @@
 
     {{ if .IsHome }}
         {{ i18n "breadcrumb_home" | title }}
+    {{ else if .Params.Filename }}
+        {{ .Params.Filename }}
     {{ else }}
         {{ .Title }}
     {{ end }}

--- a/layouts/partials/module/section_tree.html
+++ b/layouts/partials/module/section_tree.html
@@ -25,7 +25,7 @@
             {{ else }}
                 <li class="file">
                     <a href="{{ .Permalink }}" title=".{{ .RelPermalink }}">
-                        {{ .Title }}
+                        {{ if .Params.Filename }} {{ .Params.Filename }} {{ else }} {{ .Title }} {{ end }}
                     </a>
                 </li>
             {{ end }}

--- a/layouts/partials/module/show_math.html
+++ b/layouts/partials/module/show_math.html
@@ -3,6 +3,21 @@
         https://katex.org/docs/browser.html 
 -->
 
+{{ $trustedMath := false }}
+{{ if isset $.Params "trustedmath" }}
+
+    {{ if $.Params.trustedmath }}
+        {{ $trustedMath = . }}
+    {{ end }}
+
+{{ else if isset $.Site.Params.globalFrontmatter "trustedmath" }}
+
+    {{ if $.Site.Params.globalFrontmatter.trustedmath }}
+        {{ $trustedMath = . }}
+    {{ end }}
+
+{{ end }}
+
 <link
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
@@ -22,7 +37,7 @@
     src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
     integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05"
     crossorigin="anonymous"
-    onload="renderMathInElement(document.body);"></script>
+    onload="renderMathInElement(document.body{{ if $trustedMath }}, { trust: true }{{ end }});"></script>
 
 <script>
     document.addEventListener("DOMContentLoaded", function () {
@@ -37,6 +52,7 @@
             ],
             // • rendering keys, e.g.:
             throwOnError: false,
+            {{ if $trustedMath }}trust: true,{{ end }}
         });
     });
 </script>


### PR DESCRIPTION
This allows use of raw html features of katex [see docs](https://katex.org/docs/supported#html)